### PR TITLE
disable scm: avoid setuptools_scm version 8.0.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     use_scm_version=False,
     python_requires='>=3.6',
     setup_requires=[
-        'setuptools_scm >= 1.15',
+        'setuptools_scm >= 1.15,< 8.0.4',
     ],
     install_requires=[
         'sphinxcontrib-httpdomain >= 1.5.0',


### PR DESCRIPTION
`setuptools_scm` version `8.0.4` makes no longer valid to disable `scm` by setting `use_scm_version=False`. 

MR to skip this version


```
        Traceback (most recent call last):
          File "<string>", line 2, in <module>
          File "<pip-setuptools-caller>", line 34, in <module>
          File "/tmp/pip-install-622vhrs8/sphinxcontrib-openapi_fe83b0dd754741c1a65af362dba77e6d/setup.py", line 16, in <module>
            setup(
          File "/__w/pdns/pdns/docs/.venv/lib/python3.9/site-packages/setuptools/__init__.py", line 103, in setup
            return distutils.core.setup(**attrs)
          File "/__w/pdns/pdns/docs/.venv/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 147, in setup
            _setup_distribution = dist = klass(attrs)
          File "/__w/pdns/pdns/docs/.venv/lib/python3.9/site-packages/setuptools/dist.py", line 303, in __init__
            _Distribution.__init__(self, dist_attrs)
          File "/__w/pdns/pdns/docs/.venv/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 283, in __init__
            self.finalize_options()
          File "/__w/pdns/pdns/docs/.venv/lib/python3.9/site-packages/setuptools/dist.py", line 680, in finalize_options
            ep(self)
          File "/__w/pdns/pdns/docs/.venv/lib/python3.9/site-packages/setuptools/dist.py", line 700, in _finalize_setup_keywords
            ep.load()(self, ep.name, value)
          File "/tmp/pip-install-622vhrs8/sphinxcontrib-openapi_fe83b0dd754741c1a65af362dba77e6d/.eggs/setuptools_scm-8.0.4-py3.9.egg/setuptools_scm/_integration/setuptools.py", line 80, in version_keyword
            assert isinstance(value, dict), "version_keyword expects a dict or True"
        AssertionError: version_keyword expects a dict or True
        [end of output]
```